### PR TITLE
feat(helm): replace NGINX ingress with Traefik gateway + HTTPRoute

### DIFF
--- a/helm/values-prd.yaml
+++ b/helm/values-prd.yaml
@@ -60,10 +60,10 @@ hpa:
   memoryAverageUtilization: 90
   cpuAverageUtilization: 90
 
-# Set a URL to expose to the Internet.
-ingress:
-  # If set to "external", the URL will be exposed in *.thehotelsnetwork.com (public). Otherwise, it'll be exposed in *.thn.app (only accessible via VPN).
+# Set a URL to expose to the Internet via gateway + HTTPRoute.
+gateway:
+  # If set to "external", it will be exposed in *.thehotelsnetwork.com.
+  # Otherwise, it'll be exposed in *.thn.app (only accessible via VPN).
   class: "internal"
-  host: "fontless.thn.app"
-  extraConfigurationSnippet: |
+  hostname: "fontless.thn.app"
     rewrite ^/gfonts(.*) $1 break;

--- a/helm/values-stg.yaml
+++ b/helm/values-stg.yaml
@@ -46,10 +46,10 @@ deployment:
       initialDelaySeconds: 10
       periodSeconds: 300
 
-# Set a URL to expose to the Internet.
-ingress:
-  # If set to "external", the URL will be exposed in *.thehotelsnetwork.com (public). Otherwise, it'll be exposed in *.thn.app (only accessible via VPN).
+# Set a URL to expose to the Internet via gateway + HTTPRoute.
+gateway:
+  # If set to "external", it will be exposed in *.thehotelsnetwork.com.
+  # Otherwise, it'll be exposed in *.thn.app (only accessible via VPN).
   class: "internal"
-  host: "fontless.stg.thn.app"
-  extraConfigurationSnippet: |
+  hostname: "fontless.stg.thn.app"
     rewrite ^/gfonts(.*) $1 break;


### PR DESCRIPTION
## Summary\n- Replace `ingress:` with `gateway:` + `middlewares:` (where applicable) in helm values files\n- Migrates from NGINX Ingress to Traefik Gateway API\n\nSolves [SYS-6164](https://thehotelsnetwork.atlassian.net/browse/SYS-6164)

[SYS-6164]: https://thehotelsnetwork.atlassian.net/browse/SYS-6164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ