### PR TITLE
feat(helm): replace NGINX ingress with Traefik gateway + HTTPRoute

### DIFF
--- a/helm/values-prd.yaml
+++ b/helm/values-prd.yaml
@@ -60,10 +60,16 @@ hpa:
   memoryAverageUtilization: 90
   cpuAverageUtilization: 90
 
-# Set a URL to expose to the Internet.
-ingress:
-  # If set to "external", the URL will be exposed in *.thehotelsnetwork.com (public). Otherwise, it'll be exposed in *.thn.app (only accessible via VPN).
+# Set a URL to expose to the Internet via gateway + HTTPRoute.
+gateway:
+  # If set to "external", it will be exposed in *.thehotelsnetwork.com.
+  # Otherwise, it'll be exposed in *.thn.app (only accessible via VPN).
   class: "internal"
-  host: "fontless.thn.app"
-  extraConfigurationSnippet: |
-    rewrite ^/gfonts(.*) $1 break;
+  hostname: "fontless.thn.app"
+
+middlewares:
+  - name: strip-gfonts-prefix
+    spec:
+      replacePathRegex:
+        regex: "^/gfonts(.*)"
+        replacement: "$1"

--- a/helm/values-stg.yaml
+++ b/helm/values-stg.yaml
@@ -46,10 +46,16 @@ deployment:
       initialDelaySeconds: 10
       periodSeconds: 300
 
-# Set a URL to expose to the Internet.
-ingress:
-  # If set to "external", the URL will be exposed in *.thehotelsnetwork.com (public). Otherwise, it'll be exposed in *.thn.app (only accessible via VPN).
+# Set a URL to expose to the Internet via gateway + HTTPRoute.
+gateway:
+  # If set to "external", it will be exposed in *.thehotelsnetwork.com.
+  # Otherwise, it'll be exposed in *.thn.app (only accessible via VPN).
   class: "internal"
-  host: "fontless.stg.thn.app"
-  extraConfigurationSnippet: |
-    rewrite ^/gfonts(.*) $1 break;
+  hostname: "fontless.stg.thn.app"
+
+middlewares:
+  - name: strip-gfonts-prefix
+    spec:
+      replacePathRegex:
+        regex: "^/gfonts(.*)"
+        replacement: "$1"


### PR DESCRIPTION
## Summary
- Replace `ingress:` block with `gateway:` block in `helm/values-prd.yaml` and `helm/values-stg.yaml`
- `host:` → `hostname:`, comments updated to reference Gateway API
- Convert NGINX `rewrite ^/gfonts(.*) $1 break;` snippet into a Traefik `replacePathRegex` middleware (`strip-gfonts-prefix`)

## Context
Part of the migration from NGINX Ingress Controller to Traefik using Kubernetes Gateway API.

Solves [SYS-6164](https://thehotelsnetwork.atlassian.net/browse/SYS-6164)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SYS-6164]: https://thehotelsnetwork.atlassian.net/browse/SYS-6164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ