### PR TITLE
Enable service account creation in Helm values

### DIFF
--- a/helm/values-prd.yaml
+++ b/helm/values-prd.yaml
@@ -10,6 +10,10 @@ pdb:
 service:
   port: 80
 
+## Service Account
+serviceAccount:
+  create: true
+
 deployment:
   # Settings for the main deployment object.
   rollingUpdateMaxSurge: "20%"

--- a/helm/values-stg.yaml
+++ b/helm/values-stg.yaml
@@ -8,6 +8,10 @@ namespace: "fontless"
 service:
   port: 80
 
+## Service Account
+serviceAccount:
+  create: true
+  
 deployment:
   # Settings for the deployment's pods.
   datadogAnnotations: '[{"source": "fontless", "service": "fontless-stg"}]'


### PR DESCRIPTION
## Summary

- Add `serviceAccount: create: true` to K8s values files to enable IRSA annotation

## Test plan

- [ ] Verify service account is created on deployment
- [ ] Verify pod can access AWS resources via IRSA