### PR TITLE
Remove serviceAccount block from Helm values

### DIFF
--- a/helm/values-prd.yaml
+++ b/helm/values-prd.yaml
@@ -11,9 +11,6 @@ service:
   port: 80
 
 ## Service Account
-serviceAccount:
-  create: true
-
 deployment:
   # Settings for the main deployment object.
   rollingUpdateMaxSurge: "20%"

--- a/helm/values-stg.yaml
+++ b/helm/values-stg.yaml
@@ -9,9 +9,6 @@ service:
   port: 80
 
 ## Service Account
-serviceAccount:
-  create: true
-  
 deployment:
   # Settings for the deployment's pods.
   datadogAnnotations: '[{"source": "fontless", "service": "fontless-stg"}]'


### PR DESCRIPTION
## Summary

Removes the `serviceAccount` block from Helm values files. This block was previously used to create a dedicated `ServiceAccount` per service, but it is now managed centrally and no longer needs to be declared in the values.

## Changes

- Removes `serviceAccount:\n  create: true` from `values-stg.yaml` and `values-prd.yaml` (or equivalent values files)

Solves [SYS-6225](https://thehotelsnetwork.atlassian.net/browse/SYS-6225)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

[SYS-6225]: https://thehotelsnetwork.atlassian.net/browse/SYS-6225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ